### PR TITLE
Missing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Tags are not required for the tool to function.
 
 Building the relationship graph parses all commit messages across all branches in the Linux kernel repository. This takes approximately **30 seconds** and uses a few hundred MB of memory.
 
+**Parallelism**: By default, the tool uses at most 2 threads to keep memory usage low. Power users can set the `LBT_MAX_JOBS` environment variable to increase parallelism for faster execution:
+
+```bash
+LBT_MAX_JOBS=8 linux-commit-backporter backport <commit-hash> --target-kernel-version 6.12
+```
+
 **Caching opportunity**: Currently, the relationship graph is rebuilt on each invocation. If faster startup is needed, caching could be implemented by serializing/deserializing the `LinuxRelations` model. See `LinuxRelations.create()` in `src/linux_kernel_commit_relations/relations.py` for where this would be most beneficial.
 
 ## Library Usage

--- a/README.md
+++ b/README.md
@@ -100,14 +100,63 @@ It builds a dependency graph from these relationships and can identify missing f
 
 ## Command Line Interface
 
-Analyze and (optionally) backport Linux kernel commits with their full dependency context:
+The CLI uses subcommands to organize its functionality. Common options shared by all subcommands:
+
+- `--repo`: Path to the Linux kernel git repository (default: current directory)
+- `--backport-command`: Command to run for each commit (use `{commit}` as placeholder, default: `git cherry-pick {commit}`)
+
+### Backport
+
+Analyze a Linux kernel commit and backport it with its full dependency context and git-llm-pick:
 
 ```bash
-linux-commit-backporter <commit-hash> \
+linux-commit-backporter backport <commit-hash> \
     --repo /path/to/linux/repo \
-    --target-kernel-version <version>
+    --target-kernel-version <version> \
     --backport-command "git-llm-pick {commit}"
 ```
+
+**Options:**
+
+- `--target-kernel-version`: Target kernel version for backporting (required)
+- `--output tree|list`: Display format (default: tree)
+- `--commit-sort topo|nearest-commit-date|mainline-commit-date`: Sort order (default: topo)
+- `--dry-run`: List commits without backporting
+- `--max-depth`: Maximum recursion depth for dependency analysis (default: 10)
+
+### Missing-fixups
+
+Find commits in a branch range that have missing fix commits, and backport them along with their dependencies:
+
+```bash
+# Find and backport missing fixes (default behavior)
+linux-commit-backporter missing-fixups v6.12.73 v6.12.74 \
+    --repo /path/to/linux/repo \
+    --target-kernel-version 6.12
+
+# Use git-llm-pick for conflict resolution
+linux-commit-backporter missing-fixups v6.12.73 v6.12.74 \
+    --repo /path/to/linux/repo \
+    --target-kernel-version 6.12 \
+    --backport-command "git-llm-pick {commit}"
+
+# Only list missing fixes without backporting
+linux-commit-backporter missing-fixups v6.12.73 v6.12.74 \
+    --repo /path/to/linux/repo \
+    --dry-run
+
+# branch_b defaults to HEAD if omitted
+linux-commit-backporter missing-fixups v6.12.73 \
+    --repo /path/to/linux/repo \
+    --dry-run
+```
+
+**Options:**
+
+- `branch_a`: Base branch or tag (required)
+- `branch_b`: Target branch (default: HEAD)
+- `--dry-run`: List missing fixes without backporting
+- `--target-kernel-version`: Target kernel version (required unless `--dry-run`)
 
 ### Repository Requirements
 
@@ -128,15 +177,6 @@ Tags are not required for the tool to function.
 Building the relationship graph parses all commit messages across all branches in the Linux kernel repository. This takes approximately **30 seconds** and uses a few hundred MB of memory.
 
 **Caching opportunity**: Currently, the relationship graph is rebuilt on each invocation. If faster startup is needed, caching could be implemented by serializing/deserializing the `LinuxRelations` model. See `LinuxRelations.create()` in `src/linux_kernel_commit_relations/relations.py` for where this would be most beneficial.
-
-**Options:**
-
-- `--repo`: Path to the Linux kernel git repository where patches will be applied (default: current directory)
-- `--output tree|list`: Display format (default: tree)
-- `--commit-sort topo|nearest-commit-date|mainline-commit-date`: Sort order (default: topo)
-- `--target-kernel-version`: Target kernel version for backporting
-- `--dry-run`: List commits without backporting
-- `--backport-command`: Command to run for each commit (use `{commit}` as placeholder) (default: "git cherry-pick {commit}")
 
 ## Library Usage
 

--- a/src/linux_kernel_commit_relations/cli/linux_commit_backporter.py
+++ b/src/linux_kernel_commit_relations/cli/linux_commit_backporter.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from tqdm import tqdm
 
 from linux_kernel_commit_relations.commit_context import CommitRel, LinuxTag, get_commit_context
+from linux_kernel_commit_relations.missing_fixes import get_missing_fixes
 from linux_kernel_commit_relations.relations import LinuxRelations
 
 logger = logging.getLogger(__name__)
@@ -48,12 +49,148 @@ def get_rel_date(rel: CommitRel, repo_path: Path, mainline: bool = True) -> int:
     )
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Analyze commit from Linux kernel repository and backport it to a target kernel version with context"
+def add_common_arguments(parser):
+    """Add arguments shared by all subcommands."""
+    parser.add_argument("--repo", default=".", help="Path to Linux git repository (default: %(default)s)")
+    parser.add_argument(
+        "--backport-command",
+        default="git cherry-pick {commit}",
+        help="Command to backport each commit (use {commit} as placeholder, default: %(default)s)",
     )
+
+
+def _collect_fix_summaries(fix_rel):
+    """Recursively collect all SummaryRel objects from a fix tree."""
+    result = [fix_rel]
+    for nested in fix_rel.fixed_by:
+        result.extend(_collect_fix_summaries(nested))
+    return result
+
+
+def backport_commits(flattened_commits, repo_path, backport_command):
+    """Backport a list of CommitRel."""
+    total = len(flattened_commits)
+    for i, commit in enumerate(tqdm(flattened_commits, desc="Backporting commits")):
+        cmd = backport_command.format(commit=commit.nearest_commit_hash)
+        result = subprocess.run(cmd, shell=True, cwd=repo_path, check=False)
+        if result.returncode != 0:
+            logger.error("Failed to backport commit %d/%d: %s", i + 1, total, commit.summary)
+            if i + 1 < total:
+                print(f"\nRemaining {total - i - 1} commit(s) not applied:")
+                for remaining in flattened_commits[i + 1 :]:
+                    print(f"  {remaining.nearest_commit_hash[:12]} {remaining.summary}")
+            return 1
+    return 0
+
+
+def backport_command_handler(args):
+    """Analyze and backport a Linux kernel commit with its dependencies."""
+    target_tag = LinuxTag(args.target_kernel_version)
+    repo_path = Path(args.repo)
+    if not repo_path.exists():
+        raise RuntimeError(f"Repository path does not exist: {repo_path}")
+
+    relations = LinuxRelations.create(repo_path, pbar=True)
+    context = get_commit_context(
+        args.commit, relations, repo_path, target=target_tag, pbar=True, max_depth=args.max_depth
+    )
+
+    if args.commit_sort == "topo":
+        flattened_commits = context.flatten()
+    elif args.commit_sort == "nearest-commit-date":
+        flattened_commits = sorted(context.flatten(), key=lambda r: get_rel_date(r, repo_path, mainline=False))
+    elif args.commit_sort == "mainline-commit-date":
+        flattened_commits = sorted(context.flatten(), key=lambda r: get_rel_date(r, repo_path, mainline=True))
+    else:
+        raise ValueError(f"Unknown commit_sort order: {args.commit_sort}")
+
+    if args.output == "tree":
+        print(context)
+    else:
+        for commit in flattened_commits:
+            print(commit)
+
+    if args.dry_run:
+        return 0
+
+    return backport_commits(flattened_commits, repo_path, args.backport_command)
+
+
+def missing_fixups_handler(args):
+    """Find missing fixups between two kernel branches and optionally backport them."""
+    repo_path = Path(args.repo)
+    if not repo_path.exists():
+        raise RuntimeError(f"Repository path does not exist: {repo_path}")
+
+    if not args.dry_run and not args.target_kernel_version:
+        logger.error("--target-kernel-version is required unless --dry-run is specified")
+        return 1
+
+    refspec_range = f"{args.branch_a}..{args.branch_b}"
+    missing = get_missing_fixes(repo_path, refspec_range, args.branch_b)
+
+    if not missing:
+        print("No commits with missing fixes found.")
+        return 0
+
+    print(f"Found {len(missing)} commit(s) with missing fixes:\n")
+    for mf in missing:
+        print(mf)
+
+    if args.dry_run:
+        return 0
+
+    # Collect all fix SummaryRels and resolve to upstream commits.
+    # For each fix, get_commit_context resolves its dependency tree (stable_depends),
+    # so all_flattened_commits will contain both fix commits and their dependencies.
+    fix_summaries = []
+    for mf in missing:
+        for fix_rel in mf.fixed_by:
+            fix_summaries.extend(_collect_fix_summaries(fix_rel))
+
+    if not fix_summaries:
+        print("No fix commits to backport.")
+        return 0
+
+    target_tag = LinuxTag(args.target_kernel_version)
+    relations = LinuxRelations.create(repo_path, pbar=True)
+
+    all_flattened_commits = []
+    seen_commits = set()
+    for summary_rel in fix_summaries:
+        for commit_hash in summary_rel.commit_hashes:
+            try:
+                ctx = get_commit_context(
+                    commit_hash,
+                    relations,
+                    repo_path,
+                    target=target_tag,
+                    pbar=True,
+                )
+                for commit in ctx.flatten():
+                    if commit.nearest_commit_hash not in seen_commits:
+                        seen_commits.add(commit.nearest_commit_hash)
+                        all_flattened_commits.append(commit)
+                break  # one hash per summary is enough
+            except ValueError:
+                continue
+
+    print(f"\n=== Backporting {len(all_flattened_commits)} commit(s) ===\n")
+    for commit in all_flattened_commits:
+        print(f"  {commit.nearest_commit_hash[:12]} {commit.summary}")
+    print()
+    return backport_commits(all_flattened_commits, repo_path, args.backport_command)
+
+
+def add_backport_parser(subparsers):
+    """Add backport subcommand parser."""
+    parser = subparsers.add_parser(
+        "backport",
+        description="Analyze commit from Linux kernel repository and backport it to a target kernel version with context",
+    )
+    parser.set_defaults(func=backport_command_handler)
     parser.add_argument("commit", help="Commit hash to analyze and backport")
-    parser.add_argument("--repo", help="Path to Linux git repository (default: %(default)s)", default=".")
+    add_common_arguments(parser)
     parser.add_argument(
         "--output",
         choices=["tree", "list"],
@@ -66,63 +203,37 @@ def main():
         default="topo",
         help="Sort order for commit context. %(default)s is default and flattens the tree inorder with stable dependencies coming first and fixing commits last. Date sort options sort this afterwards by the respective date. Most of the time `topo` is enough.",
     )
-    parser.add_argument(
-        "--target-kernel-version",
-        required=True,
-        help="Target kernel version for backporting",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="List commits without backporting",
-    )
-    parser.add_argument(
-        "--backport-command",
-        default="git cherry-pick {commit}",
-        help="Command to backport each commit (use {commit} as placeholder, default: %(default)s)",
-    )
+    parser.add_argument("--target-kernel-version", required=True, help="Target kernel version for backporting")
+    parser.add_argument("--dry-run", action="store_true", help="List commits without backporting")
     parser.add_argument(
         "--max-depth",
         type=int,
         default=10,
         help="Maximum recursion depth for dependency analysis (default: %(default)s)",
     )
+
+
+def add_missing_fixups_parser(subparsers):
+    """Add missing-fixups subcommand parser."""
+    parser = subparsers.add_parser("missing-fixups", description="Find missing fixups between two kernel branches")
+    parser.set_defaults(func=missing_fixups_handler)
+    parser.add_argument("branch_a", help="Base branch or tag (e.g. v6.12.73)")
+    parser.add_argument("branch_b", nargs="?", default="HEAD", help="Target branch (default: %(default)s)")
+    add_common_arguments(parser)
+    parser.add_argument("--dry-run", action="store_true", help="List missing fixes without backporting")
+    parser.add_argument("--target-kernel-version", help="Target kernel version (required unless --dry-run)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Linux kernel commit analysis and backporting tool")
+    subparsers = parser.add_subparsers(dest="subcommand")
+    subparsers.required = True
+
+    add_backport_parser(subparsers)
+    add_missing_fixups_parser(subparsers)
+
     args = parser.parse_args()
-
-    target_tag = LinuxTag(args.target_kernel_version)
-    repo_path = Path(args.repo)
-    if not repo_path.exists():
-        raise RuntimeError(f"Repository path does not exist: {repo_path}")
-
-    relations = LinuxRelations.create(repo_path, pbar=True)
-    context = get_commit_context(
-        args.commit, relations, repo_path, target=target_tag, pbar=True, max_depth=args.max_depth
-    )
-
-    if args.commit_sort == "topo":
-        flattened = context.flatten()
-    elif args.commit_sort == "nearest-commit-date":
-        flattened = sorted(context.flatten(), key=lambda r: get_rel_date(r, repo_path, mainline=False))
-    elif args.commit_sort == "mainline-commit-date":
-        flattened = sorted(context.flatten(), key=lambda r: get_rel_date(r, repo_path, mainline=True))
-    else:
-        raise ValueError(f"Unknown commit_sort order: {args.commit_sort}")
-
-    if args.output == "tree":
-        print(context)
-    else:
-        for rel in flattened:
-            print(rel)
-
-    if args.dry_run:
-        return 0
-
-    if args.backport_command:
-        for rel in tqdm(flattened, desc="Backporting commits"):
-            cmd = args.backport_command.format(commit=rel.nearest_commit_hash)
-            subprocess.run(cmd, shell=True, cwd=repo_path, check=True)
-
-    return 0
+    return args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/linux_kernel_commit_relations/cli/linux_commit_backporter.py
+++ b/src/linux_kernel_commit_relations/cli/linux_commit_backporter.py
@@ -57,6 +57,12 @@ def add_common_arguments(parser):
         default="git cherry-pick {commit}",
         help="Command to backport each commit (use {commit} as placeholder, default: %(default)s)",
     )
+    parser.add_argument(
+        "--commit-source",
+        choices=["nearest", "mainline"],
+        default="mainline",
+        help="Which commit hash to backport: mainline upstream or nearest to target version (default: %(default)s)",
+    )
 
 
 def _collect_fix_summaries(fix_rel):
@@ -67,11 +73,12 @@ def _collect_fix_summaries(fix_rel):
     return result
 
 
-def backport_commits(flattened_commits, repo_path, backport_command):
+def backport_commits(flattened_commits, repo_path, backport_command, commit_source="mainline"):
     """Backport a list of CommitRel."""
     total = len(flattened_commits)
     for i, commit in enumerate(tqdm(flattened_commits, desc="Backporting commits")):
-        cmd = backport_command.format(commit=commit.nearest_commit_hash)
+        commit_hash = commit.mainline_commit_hash if commit_source == "mainline" else commit.nearest_commit_hash
+        cmd = backport_command.format(commit=commit_hash)
         result = subprocess.run(cmd, shell=True, cwd=repo_path, check=False)
         if result.returncode != 0:
             logger.error("Failed to backport commit %d/%d: %s", i + 1, total, commit.summary)
@@ -85,7 +92,10 @@ def backport_commits(flattened_commits, repo_path, backport_command):
 
 def backport_command_handler(args):
     """Analyze and backport a Linux kernel commit with its dependencies."""
-    target_tag = LinuxTag(args.target_kernel_version)
+    if args.commit_source == "nearest" and not args.target_kernel_version:
+        logger.error("--target-kernel-version is required with --commit-source nearest")
+        return 1
+    target_tag = LinuxTag(args.target_kernel_version) if args.target_kernel_version else None
     repo_path = Path(args.repo)
     if not repo_path.exists():
         raise RuntimeError(f"Repository path does not exist: {repo_path}")
@@ -113,7 +123,7 @@ def backport_command_handler(args):
     if args.dry_run:
         return 0
 
-    return backport_commits(flattened_commits, repo_path, args.backport_command)
+    return backport_commits(flattened_commits, repo_path, args.backport_command, args.commit_source)
 
 
 def missing_fixups_handler(args):
@@ -122,8 +132,8 @@ def missing_fixups_handler(args):
     if not repo_path.exists():
         raise RuntimeError(f"Repository path does not exist: {repo_path}")
 
-    if not args.dry_run and not args.target_kernel_version:
-        logger.error("--target-kernel-version is required unless --dry-run is specified")
+    if not args.dry_run and args.commit_source == "nearest" and not args.target_kernel_version:
+        logger.error("--target-kernel-version is required with --commit-source nearest")
         return 1
 
     refspec_range = f"{args.branch_a}..{args.branch_b}"
@@ -152,7 +162,7 @@ def missing_fixups_handler(args):
         print("No fix commits to backport.")
         return 0
 
-    target_tag = LinuxTag(args.target_kernel_version)
+    target_tag = LinuxTag(args.target_kernel_version) if args.target_kernel_version else None
     relations = LinuxRelations.create(repo_path, pbar=True)
 
     all_flattened_commits = []
@@ -175,11 +185,12 @@ def missing_fixups_handler(args):
             except ValueError:
                 continue
 
-    print(f"\n=== Backporting {len(all_flattened_commits)} commit(s) ===\n")
+    print(f"\n=== Backporting {len(all_flattened_commits)} commit(s) ({args.commit_source}) ===\n")
     for commit in all_flattened_commits:
-        print(f"  {commit.nearest_commit_hash[:12]} {commit.summary}")
+        h = commit.mainline_commit_hash if args.commit_source == "mainline" else commit.nearest_commit_hash
+        print(f"  {h[:12]} {commit.summary}")
     print()
-    return backport_commits(all_flattened_commits, repo_path, args.backport_command)
+    return backport_commits(all_flattened_commits, repo_path, args.backport_command, args.commit_source)
 
 
 def add_backport_parser(subparsers):
@@ -203,7 +214,9 @@ def add_backport_parser(subparsers):
         default="topo",
         help="Sort order for commit context. %(default)s is default and flattens the tree inorder with stable dependencies coming first and fixing commits last. Date sort options sort this afterwards by the respective date. Most of the time `topo` is enough.",
     )
-    parser.add_argument("--target-kernel-version", required=True, help="Target kernel version for backporting")
+    parser.add_argument(
+        "--target-kernel-version", help="Target kernel version for backporting (required with --commit-source nearest)"
+    )
     parser.add_argument("--dry-run", action="store_true", help="List commits without backporting")
     parser.add_argument(
         "--max-depth",

--- a/src/linux_kernel_commit_relations/commit_context.py
+++ b/src/linux_kernel_commit_relations/commit_context.py
@@ -236,7 +236,7 @@ def _summary_to_commit_rel(
         pbar_obj.update(1)
 
     commits = list(relations.summaries[summary_rel.summary])
-    _max_workers = min(max(4, os.cpu_count() or 4), len(commits))
+    _max_workers = min(int(os.environ.get("LBT_MAX_JOBS", 2)), len(commits))
     with ThreadPoolExecutor(max_workers=_max_workers) as pool:
         tag_results = list(pool.map(lambda c: get_mainline_tags(c, repo_path), commits))
     tagged_commits: list[tuple[LinuxTag, str]] = []

--- a/src/linux_kernel_commit_relations/relations.py
+++ b/src/linux_kernel_commit_relations/relations.py
@@ -13,6 +13,7 @@ __copyright__ = "Copyright Amazon.com, Inc. or its affiliates. All Rights Reserv
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
 import re
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
@@ -124,7 +125,8 @@ class LinuxRelations(pydantic.BaseModel):
         Returns:
             LinuxRelations object with all parsed relationships
         """
-        with ThreadPoolExecutor() as executor:
+        _max_workers = int(os.environ.get("LBT_MAX_JOBS", 2))
+        with ThreadPoolExecutor(max_workers=_max_workers) as executor:
             summaries_future = executor.submit(LinuxRelations.get_summaries, repo_path, refspec, pbar, 0)
             relations_future = executor.submit(LinuxRelations.get_relations, repo_path, refspec, pbar, 1)
 

--- a/test/test_backporter_cli.py
+++ b/test/test_backporter_cli.py
@@ -80,6 +80,21 @@ def test_backport_commits_success(tmp_path):
         mock_run.return_value = MagicMock(returncode=0)
         result = backport_commits([commit], tmp_path, "git cherry-pick {commit}")
     assert result == 0
+    mock_run.assert_called_once_with("git cherry-pick def456", shell=True, cwd=tmp_path, check=False)
+
+
+def test_backport_commits_nearest(tmp_path):
+    commit = CommitRel(
+        summary="test",
+        nearest_commit_hash="abc123",
+        mainline_commit_hash="def456",
+        stable_depends=[],
+        fixed_by=[],
+    )
+    with patch("linux_kernel_commit_relations.cli.linux_commit_backporter.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = backport_commits([commit], tmp_path, "git cherry-pick {commit}", "nearest")
+    assert result == 0
     mock_run.assert_called_once_with("git cherry-pick abc123", shell=True, cwd=tmp_path, check=False)
 
 
@@ -113,7 +128,7 @@ def test_missing_fixups_no_missing(tmp_path):
     assert result == 0
 
 
-def test_missing_fixups_requires_target_version(tmp_path):
+def test_missing_fixups_requires_target_version_for_nearest(tmp_path):
     fix = SummaryRel(summary="fix", stable_depends=[], fixed_by=[], commit_hashes={"fff"})
     mf = SummaryRel(summary="buggy", stable_depends=[], fixed_by=[fix], commit_hashes={"aaa"})
 
@@ -122,6 +137,7 @@ def test_missing_fixups_requires_target_version(tmp_path):
     args.branch_a = "v1"
     args.branch_b = "v2"
     args.dry_run = False
+    args.commit_source = "nearest"
     args.target_kernel_version = None
 
     with patch("linux_kernel_commit_relations.cli.linux_commit_backporter.get_missing_fixes", return_value=[mf]):

--- a/test/test_backporter_cli.py
+++ b/test/test_backporter_cli.py
@@ -1,0 +1,129 @@
+"""Tests for the linux-commit-backporter CLI subcommand structure."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from linux_kernel_commit_relations.cli.linux_commit_backporter import (
+    _collect_fix_summaries,
+    backport_commits,
+    main,
+    missing_fixups_handler,
+)
+from linux_kernel_commit_relations.commit_context import CommitRel
+from linux_kernel_commit_relations.summary_context import SummaryRel
+
+
+def test_main_requires_subcommand():
+    with pytest.raises(SystemExit):
+        with patch("sys.argv", ["linux-commit-backporter"]):
+            main()
+
+
+def test_main_backport_requires_commit_and_target(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog", "backport"])
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_main_missing_fixups_defaults_branch_b(tmp_path):
+    """missing-fixups should accept a single positional arg, defaulting branch_b to HEAD."""
+    fake_repo = str(tmp_path / "no_such_repo")
+    with patch("sys.argv", ["prog", "missing-fixups", "v6.12.73", "--repo", fake_repo]):
+        with pytest.raises(RuntimeError, match="does not exist"):
+            main()
+
+
+def test_main_missing_fixups_repo_not_found(tmp_path):
+    fake_repo = str(tmp_path / "no_such_repo")
+    with patch("sys.argv", ["prog", "missing-fixups", "v6.12.73", "v6.12.74", "--repo", fake_repo]):
+        with pytest.raises(RuntimeError, match="does not exist"):
+            main()
+
+
+def test_main_backport_repo_not_found(tmp_path):
+    fake_repo = str(tmp_path / "no_such_repo")
+    with patch("sys.argv", ["prog", "backport", "abc123", "--target-kernel-version", "6.12", "--repo", fake_repo]):
+        with pytest.raises(RuntimeError, match="does not exist"):
+            main()
+
+
+def test_collect_fix_summaries_single():
+    fix = SummaryRel(summary="fix1", stable_depends=[], fixed_by=[], commit_hashes={"aaa"})
+    assert _collect_fix_summaries(fix) == [fix]
+
+
+def test_collect_fix_summaries_nested():
+    nested = SummaryRel(summary="nested", stable_depends=[], fixed_by=[], commit_hashes={"bbb"})
+    fix = SummaryRel(summary="fix1", stable_depends=[], fixed_by=[nested], commit_hashes={"aaa"})
+    result = _collect_fix_summaries(fix)
+    assert result == [fix, nested]
+
+
+def test_collect_fix_summaries_deep():
+    deep = SummaryRel(summary="deep", stable_depends=[], fixed_by=[], commit_hashes={"ccc"})
+    mid = SummaryRel(summary="mid", stable_depends=[], fixed_by=[deep], commit_hashes={"bbb"})
+    top = SummaryRel(summary="top", stable_depends=[], fixed_by=[mid], commit_hashes={"aaa"})
+    result = _collect_fix_summaries(top)
+    assert [r.summary for r in result] == ["top", "mid", "deep"]
+
+
+def test_backport_commits_success(tmp_path):
+    commit = CommitRel(
+        summary="test",
+        nearest_commit_hash="abc123",
+        mainline_commit_hash="def456",
+        stable_depends=[],
+        fixed_by=[],
+    )
+    with patch("linux_kernel_commit_relations.cli.linux_commit_backporter.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        result = backport_commits([commit], tmp_path, "git cherry-pick {commit}")
+    assert result == 0
+    mock_run.assert_called_once_with("git cherry-pick abc123", shell=True, cwd=tmp_path, check=False)
+
+
+def test_backport_commits_failure_stops(tmp_path):
+    commits = [
+        CommitRel(summary="c1", nearest_commit_hash="aaa", mainline_commit_hash="bbb", stable_depends=[], fixed_by=[]),
+        CommitRel(summary="c2", nearest_commit_hash="ccc", mainline_commit_hash="ddd", stable_depends=[], fixed_by=[]),
+    ]
+    with patch("linux_kernel_commit_relations.cli.linux_commit_backporter.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1)
+        result = backport_commits(commits, tmp_path, "git cherry-pick {commit}")
+    assert result == 1
+    # Should stop after first failure
+    assert mock_run.call_count == 1
+
+
+def test_backport_commits_empty(tmp_path):
+    result = backport_commits([], tmp_path, "git cherry-pick {commit}")
+    assert result == 0
+
+
+def test_missing_fixups_no_missing(tmp_path):
+    args = MagicMock()
+    args.repo = str(tmp_path)
+    args.branch_a = "v1"
+    args.branch_b = "v2"
+    args.dry_run = True
+
+    with patch("linux_kernel_commit_relations.cli.linux_commit_backporter.get_missing_fixes", return_value=[]):
+        result = missing_fixups_handler(args)
+    assert result == 0
+
+
+def test_missing_fixups_requires_target_version(tmp_path):
+    fix = SummaryRel(summary="fix", stable_depends=[], fixed_by=[], commit_hashes={"fff"})
+    mf = SummaryRel(summary="buggy", stable_depends=[], fixed_by=[fix], commit_hashes={"aaa"})
+
+    args = MagicMock()
+    args.repo = str(tmp_path)
+    args.branch_a = "v1"
+    args.branch_b = "v2"
+    args.dry_run = False
+    args.target_kernel_version = None
+
+    with patch("linux_kernel_commit_relations.cli.linux_commit_backporter.get_missing_fixes", return_value=[mf]):
+        result = missing_fixups_handler(args)
+    assert result == 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change introduced subcommands for the linux backporter to search the current linux tree for missing fixes, and allow to backport them if required.

### Testing Done

Run missing-fixups from v6.12.72 on v6.12.74 on Linux tag v6.12.74

```
LBT_MAX_JOBS=2 \
    time \
    ./test/test-in-venv.sh linux-commit-backporter missing-fixups \
        --backport --target-kernel-version 6.12 \
        --repo ../Linux \
        v6.12.72 2>&1 \
        | grep -E '(Found|=== Back|  [0-9a-f]|Failed|detached|elapsed|No commits)
```
with output

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

```
Found 1 commit(s) with missing fixes:
Loading summaries: 5867it [00:00, 19430.37it/s]sing lock in fsl_xcvr_mode_put()")
Converting summary relations to commit relations: 100%|██████████| 1/1 [01:40<00:00, 100.16s/it]
=== Backporting 1 commit(s) ===
  b0f74f5d24fe ASoC: fsl_xcvr: Revert fix missing lock in fsl_xcvr_mode_put()
Backporting commits:   0%|          | 0/1 [00:00<?, ?it/s][detached HEAD ac98a79be2bcf] ASoC: fsl_xcvr: Revert fix missing lock in fsl_xcvr_mode_put()
Backporting commits: 100%|██████████| 1/1 [00:01<00:00,  1.23s/it]
345.67user 32.84system 3:16.84elapsed 192%CPU (0avgtext+0avgdata 4533540maxresident)k
```

FWIW, the missing fix is already available in v6.12.75.