### PR TITLE
github,workflow: use env variable

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -46,8 +46,10 @@ jobs:
         echo "Base branch coverage: $BASE_COVERAGE%"
 
     - name: Get PR coverage
+      env:
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        git checkout ${{ github.event.pull_request.head.sha }}
+        git checkout "$PR_HEAD_SHA"
         python -m pytest --cov-report=json:coverage-pr.json --tb=no -q
         PR_COVERAGE=$(python -c "import json; print(json.load(open('coverage-pr.json'))['totals']['percent_covered'])")
         echo "PR_COVERAGE=$PR_COVERAGE" >> $GITHUB_ENV
@@ -56,9 +58,10 @@ jobs:
     - name: Compare coverage and enforce increase
       run: |
         python -c "
+        import os
         import sys
-        base = float('${{ env.BASE_COVERAGE }}')
-        pr = float('${{ env.PR_COVERAGE }}')
+        base = float(os.environ['BASE_COVERAGE'])
+        pr = float(os.environ['PR_COVERAGE'])
         diff = pr - base
 
         print(f'Coverage Report')


### PR DESCRIPTION
When using github events, use an environment variable to avoid injecting event values into script. This follows the github action security guide.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
